### PR TITLE
Remove the leading / for ssm path

### DIFF
--- a/.changeset/giant-cars-shave.md
+++ b/.changeset/giant-cars-shave.md
@@ -1,0 +1,5 @@
+---
+'@etrigan/config-driver-ssm': minor
+---
+
+Remove leading / when specifying SSM path (breaking)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
     run:
         name: Run

--- a/packages/config-driver-ssm/src/index.ts
+++ b/packages/config-driver-ssm/src/index.ts
@@ -85,7 +85,7 @@ export const parameterStoreConfigDriver = {
     },
     async fromConnectionString(config: string) {
         const directives = config.split(' ')
-        const path = '/' + directives.shift()
+        const path = directives.shift() || ''
         let region: string | undefined = undefined
         directives.forEach(directive => {
             const [key, val] = directive.split('=')


### PR DESCRIPTION
We include a leading / on all paths, but having etrigan adding it means the config path doesn't match the SSM param store path exactly

I ended up with a `//` because I didn't expect this