### PR TITLE
Use named import rather than deep import for uuid

### DIFF
--- a/.changeset/large-bulldogs-cross.md
+++ b/.changeset/large-bulldogs-cross.md
@@ -1,0 +1,5 @@
+---
+'@etrigan/logging': patch
+---
+
+Removed deprecation warning from deep import of uuid

--- a/packages/logging/src/logging-middleware.ts
+++ b/packages/logging/src/logging-middleware.ts
@@ -1,5 +1,5 @@
 import express from 'express-serve-static-core'
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 import { Logger } from 'typescript-log'
 import { logEscalator, EscalatingLog } from './log-escalator'
 


### PR DESCRIPTION
Deep imports for uuid are deprecated https://github.com/uuidjs/uuid#deep-requires-now-deprecated

The deprecation warning comes up when `uuid()` is called, so I tested it by just adding a `console.log(uuidv4())` and running the tests.