### PR TITLE
Allow the feature updater to return null which will skip writing the …

### DIFF
--- a/.changeset/eight-pets-bow.md
+++ b/.changeset/eight-pets-bow.md
@@ -1,0 +1,5 @@
+---
+'@etrigan/feature-toggles': minor
+---
+
+Allow the feature updater to return null which will skip writing the feature state file and just use the existing values


### PR DESCRIPTION
…feature state file and just use the existing values