### PR TITLE
add pino timestamp generator function sumoTimestamp

### DIFF
--- a/.changeset/green-years-pay.md
+++ b/.changeset/green-years-pay.md
@@ -1,0 +1,5 @@
+---
+'@etrigan/logging': minor
+---
+
+Add pino timestamp generator sumoTimestamp

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -1,3 +1,4 @@
 export * from './log-escalator'
 export * from './logging-middleware'
 export * from './serialisers'
+export * from './pino-time-functions/sumo-timestamp'

--- a/packages/logging/src/pino-time-functions/sumo-timestamp.ts
+++ b/packages/logging/src/pino-time-functions/sumo-timestamp.ts
@@ -1,0 +1,22 @@
+/**
+ * A custom timestamp function for use by pino.
+ * 
+ * By default, pino uses pino.stdTimeFunctions.epochTime to
+ * generate a timestamp and add it to the `time` field.
+ * 
+ * This function generates the same timestamp, but adds it to
+ * the `timestamp` field instead, as a string instead of a
+ * number.
+ * 
+ * This matches the format in sumologic's documentation.
+ * 
+ * ```ts
+ * import { sumoTimestamp } from '@etrigan/logging'
+ * pino({
+ *   timestamp: sumoTimestamp,
+ * })
+ * ```
+ */
+ export function sumoTimestamp(): string {
+    return `,"timestamp":"${Date.now()}"`
+}


### PR DESCRIPTION
By default, pino uses the generator function pino.stdTimeFunctions.epochTime to generate a timestamp and add it to the `time` field.

This PR adds a custom generator function that uses sumologic's expected `timestamp` field instead.

```ts
import { sumoTimestamp } from '@etrigan/logging'
pino({
  timestamp: sumoTimestamp,
})
```