### PR TITLE
Enable usage in unclustered environment

### DIFF
--- a/.changeset/purple-chairs-lick.md
+++ b/.changeset/purple-chairs-lick.md
@@ -1,0 +1,5 @@
+---
+'@etrigan/feature-toggles': minor
+---
+
+Allow FeatureUpdater to be used similarly to FeatureReceiver to enable usage in a non-clustered approach

--- a/packages/feature-toggles/src/feature-updater.ts
+++ b/packages/feature-toggles/src/feature-updater.ts
@@ -20,6 +20,10 @@ export class FeatureUpdater extends EventEmitter {
         this.featureValues = initialFeatureState
     }
 
+    get featureState(): RawFeatureValues {
+        return this.featureValues
+    }
+
     async updateToggleState(featureValues: RawFeatureValues): Promise<void> {
         this.featureValues = featureValues
         this.log.debug({ featureValues: this.featureValues }, `New feature set received`)

--- a/packages/feature-toggles/src/middleware.ts
+++ b/packages/feature-toggles/src/middleware.ts
@@ -2,6 +2,7 @@ import express from 'express-serve-static-core'
 
 import { FeatureState, toFeatureState } from '@etrigan/feature-toggles-client'
 import { FeatureReceiver } from './feature-receiver'
+import { FeatureUpdater } from './feature-updater'
 
 export interface WithFeatures {
     features: FeatureState
@@ -15,7 +16,9 @@ declare global {
     }
 }
 
-export function createFeatureStateMiddleware(featureReceiver: FeatureReceiver): express.Handler {
+export function createFeatureStateMiddleware(
+    featureManager: FeatureReceiver | FeatureUpdater,
+): express.Handler {
     return feaureStateMiddleware
 
     function feaureStateMiddleware(
@@ -23,7 +26,7 @@ export function createFeatureStateMiddleware(featureReceiver: FeatureReceiver): 
         _res: express.Response,
         next: express.NextFunction,
     ) {
-        req.features = toFeatureState(featureReceiver.featureState)
+        req.features = toFeatureState(featureManager.featureState)
 
         next()
     }


### PR DESCRIPTION
**Issue**

Unable to use the middleware when express is running unclustered since `FeatureReceiver` only works in a clustered environment.

**Changes Made**

`FeatureUpdater` to have the same `featureState` property as `FeatureReceiver` so it can be used in the same way where `FeatureReceiver` is being used.